### PR TITLE
bugfix: `LocalDate.now()` static 제거, 메서드 내 필드로 이동

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'com.devspacehub'
-version = '0.3.1'
+version = '0.3.2'
 
 java {
 	sourceCompatibility = '17'

--- a/src/main/java/com/devspacehub/ast/common/constant/CommonConstants.java
+++ b/src/main/java/com/devspacehub/ast/common/constant/CommonConstants.java
@@ -8,8 +8,6 @@
 
 package com.devspacehub.ast.common.constant;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 /**
@@ -36,19 +34,19 @@ public class CommonConstants {
     /**
      * 현지(KR) 기준 국내 장 시작 시각
      */
-    public static final LocalDateTime DOMESTIC_MARKET_START_DATETIME_KST = LocalDateTime.of(LocalDate.now(), LocalTime.of(9, 0, 0));
+    public static final LocalTime DOMESTIC_MARKET_OPEN_TIME_KST = LocalTime.of(9, 0, 0);
     /**
      * 현지(KR) 기준 국내 장 마감 시각
      */
-    public static final LocalDateTime DOMESTIC_MARKET_END_DATETIME_KST = LocalDateTime.of(LocalDate.now(), LocalTime.of(16, 0, 0));
+    public static final LocalTime DOMESTIC_MARKET_CLOSE_TIME_KST = LocalTime.of(16, 0, 0);
 
     /**
      * 현지(KR) 기준 해외 장 시작 시각
      */
-    public static final LocalDateTime OVERSEAS_MARKET_START_DATETIME_KST = LocalDateTime.of(LocalDate.now(), LocalTime.of(22, 0, 0));
+    public static final LocalTime OVERSEAS_MARKET_OPEN_TIME_KST = LocalTime.of(22, 0, 0);
     /**
      * 현지(KR) 기준 해외 장 마감 시각
      */
-    public static final LocalDateTime OVERSEAS_MARKET_END_DATETIME_KST = LocalDateTime.of(LocalDate.now().plusDays(1), LocalTime.of(6, 0, 0));
+    public static final LocalTime OVERSEAS_MARKET_CLOSE_TIME_KST = LocalTime.of(6, 0, 0);
 
 }

--- a/src/main/java/com/devspacehub/ast/domain/my/stockBalance/dto/response/StockBalanceApiResDto.java
+++ b/src/main/java/com/devspacehub/ast/domain/my/stockBalance/dto/response/StockBalanceApiResDto.java
@@ -66,7 +66,7 @@ public class StockBalanceApiResDto extends WebClientCommonResDto {
         private String thdtSllQty;
 
         @JsonProperty("hldg_qty")
-        private int holdingQuantity;         // 보유 수량
+        private int holdingQuantity;         // 보유 수량. 체결 날 + 2일 동안 0으로 응답함.
 
         @JsonProperty("ord_psbl_qty")
         private String orderPossibleQuantity;   // 주문 가능 수량

--- a/src/main/java/com/devspacehub/ast/domain/orderTrading/service/TradingService.java
+++ b/src/main/java/com/devspacehub/ast/domain/orderTrading/service/TradingService.java
@@ -73,7 +73,7 @@ public abstract class TradingService {
     }
 
     /**
-     * 종목에 대해 새 주문인지 체크
+     * 전달받은 종목의 주문 종류(매수/매도)에 대해 최초 주문인지 체크한다.
      * @param itemCode     String 타입의 종목 코드
      * @param transactionId 트랜잭션 Id
      * @param marketStart 장 시작 시각

--- a/src/test/java/com/devspacehub/ast/domain/orderTrading/service/SellOrderIntegrationTest.java
+++ b/src/test/java/com/devspacehub/ast/domain/orderTrading/service/SellOrderIntegrationTest.java
@@ -8,7 +8,6 @@
 
 package com.devspacehub.ast.domain.orderTrading.service;
 
-import com.devspacehub.ast.common.constant.CommonConstants;
 import com.devspacehub.ast.domain.orderTrading.OrderTrading;
 import com.devspacehub.ast.domain.orderTrading.OrderTradingRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -36,17 +35,16 @@ class SellOrderIntegrationTest {
     private SellOrderServiceImpl sellOrderService;
     @Value("${openapi.rest.transaction-id.domestic.sell-order}")
     private String sellTxId;
-    private static final int MARKET_START_HOUR = 9;
-    private static final int MARKET_END_HOUR = 16;
+    private static final LocalTime MARKET_OPEN_TIME = LocalTime.of(9, 0, 0);
+    private static final LocalTime MARKET_CLOSE_TIME = LocalTime.of(16, 0, 0);
 
-    // TODO 테스트코드 성공 위해 .registerDateTime() 을 세팅할 수 있도록 해야 한다.
     @Test
     @DisplayName("전달한 종목으로 전달한 기간 사이에 이미 성공한 매도 주문 이력이 있다면 False를 반환한다.")
     void isNewOrder_failed() {
         // given
         final String alreadyOrderedItemCode = "000000";
         LocalDate today = LocalDate.now();
-        LocalDateTime givenDateTime = LocalDateTime.of(today, LocalTime.of(MARKET_START_HOUR, 30, 0));
+        LocalDateTime givenDateTime = LocalDateTime.of(today, LocalTime.of(9, 30, 0));
 
         orderTradingRepository.save(OrderTrading.builder()
                 .seq(0L)
@@ -67,8 +65,7 @@ class SellOrderIntegrationTest {
 
         // when
         boolean result = sellOrderService.isNewOrder(alreadyOrderedItemCode, sellTxId,
-                LocalDateTime.of(today, LocalTime.of(MARKET_START_HOUR, 0, 0)),
-                LocalDateTime.of(today, LocalTime.of(MARKET_END_HOUR, 0, 0))
+                LocalDateTime.of(today, MARKET_OPEN_TIME), LocalDateTime.of(today, MARKET_CLOSE_TIME)
         );
         // then
         assertThat(result).isFalse();
@@ -81,7 +78,7 @@ class SellOrderIntegrationTest {
         final String alreadyOrderedItemCode = "000000";
         final String notOrderedItemCode = "100000";
         LocalDate today = LocalDate.now();
-        LocalDateTime givenOrderDateTime = LocalDateTime.of(today, LocalTime.of(MARKET_START_HOUR, 30, 0));
+        LocalDateTime givenOrderDateTime = LocalDateTime.of(today, LocalTime.of(9, 30, 0));
 
         orderTradingRepository.save(OrderTrading.builder()
                 .seq(0L)
@@ -102,7 +99,8 @@ class SellOrderIntegrationTest {
 
         // when
         boolean result = sellOrderService.isNewOrder(notOrderedItemCode, sellTxId,
-                CommonConstants.DOMESTIC_MARKET_START_DATETIME_KST, CommonConstants.DOMESTIC_MARKET_END_DATETIME_KST);
+                LocalDateTime.of(today, MARKET_OPEN_TIME), LocalDateTime.of(today, MARKET_CLOSE_TIME));
+
         // then
         assertThat(result).isTrue();
     }

--- a/src/test/java/com/devspacehub/ast/domain/orderTrading/service/SellOrderServiceImplTest.java
+++ b/src/test/java/com/devspacehub/ast/domain/orderTrading/service/SellOrderServiceImplTest.java
@@ -8,7 +8,6 @@
 
 package com.devspacehub.ast.domain.orderTrading.service;
 
-import com.devspacehub.ast.common.constant.CommonConstants;
 import com.devspacehub.ast.domain.marketStatus.dto.StockItemDto;
 import com.devspacehub.ast.domain.my.service.MyServiceFactory;
 import com.devspacehub.ast.domain.my.stockBalance.dto.response.StockBalanceApiResDto;
@@ -24,6 +23,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 
 import static com.devspacehub.ast.common.constant.CommonConstants.OPENAPI_SUCCESS_RESULT_CODE;
@@ -45,6 +47,8 @@ class SellOrderServiceImplTest {
 
     @Value("${openapi.rest.transaction-id.domestic.sell-order}")
     private String sellOrderTxId;
+    private static final LocalTime MARKET_OPEN_TIME = LocalTime.of(9, 0, 0);
+    private static final LocalTime MARKET_CLOSE_TIME = LocalTime.of(16, 0, 0);
 
     @BeforeEach
     void setUp() {
@@ -88,6 +92,7 @@ class SellOrderServiceImplTest {
     @DisplayName("보유 수량이 1개 이상이고 주문 성공 이력이 없고 매도 지표에 부합하면 매도 주문 종목 리스트에 포함한다.")
     void pickStockItemsIncluded() {
         // given
+        LocalDate today = LocalDate.now();
         StockBalanceApiResDto.MyStockBalance givenLossSellItem = new StockBalanceApiResDto.MyStockBalance(
                 "000002", "", "", "", "", "", "",
                 1, "", "","",
@@ -106,11 +111,11 @@ class SellOrderServiceImplTest {
 
         given(orderTradingRepository.countByItemCodeAndOrderResultCodeAndTransactionIdAndRegistrationDateTimeBetween(
                 givenLossSellItem.getItemCode(), OPENAPI_SUCCESS_RESULT_CODE, sellOrderTxId,
-                CommonConstants.DOMESTIC_MARKET_START_DATETIME_KST, CommonConstants.DOMESTIC_MARKET_END_DATETIME_KST)
+                LocalDateTime.of(today, MARKET_OPEN_TIME), LocalDateTime.of(today, MARKET_CLOSE_TIME))
         ).willReturn(0);
         given(orderTradingRepository.countByItemCodeAndOrderResultCodeAndTransactionIdAndRegistrationDateTimeBetween(
                 givenProfitSellItem.getItemCode(), OPENAPI_SUCCESS_RESULT_CODE, sellOrderTxId,
-                CommonConstants.DOMESTIC_MARKET_START_DATETIME_KST, CommonConstants.DOMESTIC_MARKET_END_DATETIME_KST)
+                LocalDateTime.of(today, MARKET_OPEN_TIME), LocalDateTime.of(today, MARKET_CLOSE_TIME))
         ).willReturn(0);
 
         // when
@@ -125,6 +130,7 @@ class SellOrderServiceImplTest {
     @DisplayName("이미 체결된 종목이거나 매도 주문한 이력이 있으면 매도 주문 종목 리스트에 포함하지 않는다.")
     void pickStockItemsNotIncluded() {
         // given
+        LocalDate today = LocalDate.now();
         StockBalanceApiResDto.MyStockBalance alreadyOrdered = new StockBalanceApiResDto.MyStockBalance(
                 "000000", "", "", "", "", "", "",
                 1, "", "","",
@@ -142,7 +148,7 @@ class SellOrderServiceImplTest {
 
         given(orderTradingRepository.countByItemCodeAndOrderResultCodeAndTransactionIdAndRegistrationDateTimeBetween(
                 alreadyOrdered.getItemCode(), OPENAPI_SUCCESS_RESULT_CODE, sellOrderTxId,
-                CommonConstants.DOMESTIC_MARKET_START_DATETIME_KST, CommonConstants.DOMESTIC_MARKET_END_DATETIME_KST)
+                LocalDateTime.of(today, MARKET_OPEN_TIME), LocalDateTime.of(today, MARKET_CLOSE_TIME))
         ).willReturn(1);
 
         // when


### PR DESCRIPTION
### 이슈 : 
기존에 개발되어 있던 국내/해외의 매수/매도 주문에서 당일날 이미 주문이 발생한 종목에 대해 중복으로 주문을 넣는 이슈 발생 

### 이슈 원인 및 현상 :
종목에 대해 중복 주문 여부를 검증하는 쿼리문에 전달하는 
주식 장 시작/종료 일시 값을 클래스의 `static final`로 선언함으로 인해 애플리케이션 기동 시 최초 bean이 생성될 때의 값으로 고정 할당되어
애플리케이션 기동 다음 날부터 문제가 발생하는 현상이 재현됨.

### 이슈 해결 : 
메서드가 호출될 때마다 값이 할당되어야 하는 `LocalTime` 값을 메서드 내로 이동시켰음.
시각 값은 고정되어도 되므로 공통 상수 클래스로 두었음.

### 커밋 내역 :
- bugfix: LocalDate.now() 를 static 제거, 메서드 내 필드로 이동
- refactor: JavaDoc 수정, 주석 추가