### PR TITLE
feat : 해외 주식 체결 결과 후처리 API + 국내/해외 체결결과내역조회 API 연쇄적으로 호출할 수 있도록 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'com.devspacehub'
-version = '0.3.3'
+version = '0.3.4'
 
 java {
 	sourceCompatibility = '17'

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ clean.doLast {
 
 test {
 	// 테스트에 사용할 환경 변수 설정
-	systemProperty "DB_URL", "jdbc:mysql://34.69.203.91:3306/astDB_BETA?serverTimezone=Asia/Seoul&characterEncoding=UTF-8"
+	systemProperty "DB_URL", "jdbc:mysql://34.31.120.3:3306/astDB_BETA?serverTimezone=Asia/Seoul&characterEncoding=UTF-8"
 	systemProperty "DB_USERNAME", "devSpaceHub_BETA"
 	systemProperty "DB_PASSWORD", "devSpaceHub_BETA123"
 	systemProperty "COMPREHENSIVE_ACCOUNTNUMBER", "50099723"

--- a/src/main/java/com/devspacehub/ast/common/constant/OpenApiType.java
+++ b/src/main/java/com/devspacehub/ast/common/constant/OpenApiType.java
@@ -37,7 +37,8 @@ public enum OpenApiType {
 
     OVERSEAS_BUY_ORDER_POSSIBLE_CASH("/uapi/overseas-stock/v1/trading/inquire-psamount", "OV004", "해외 매수 가능 금액 조회"),
     OVERSEAS_STOCK_BALANCE("/uapi/overseas-stock/v1/trading/inquire-balance", "OV005", "해외 주식 잔고 조회"),
-    OVERSEAS_STOCK_CONDITION_SEARCH("/uapi/overseas-price/v1/quotations/inquire-search", "OV006", "해외주식 조건검색")
+    OVERSEAS_STOCK_CONDITION_SEARCH("/uapi/overseas-price/v1/quotations/inquire-search", "OV006", "해외주식 조건검색"),
+    OVERSEAS_ORDER_CONCLUSION_FIND("/uapi/overseas-stock/v1/trading/inquire-ccnl", "OV007", "해외주식 주문체결내역")
     ;
 
     private final String uri;

--- a/src/main/java/com/devspacehub/ast/common/utils/NumberUtils.java
+++ b/src/main/java/com/devspacehub/ast/common/utils/NumberUtils.java
@@ -1,0 +1,26 @@
+/*
+ © 2024 devspacehub, Inc. All rights reserved.
+
+ name : NumberUtils
+ creation : 2024.8.30
+ author : Yoonji Moon
+ */
+
+package com.devspacehub.ast.common.utils;
+
+/**
+ * 숫자 관련 유틸성 클래스
+ */
+public class NumberUtils {
+
+    /**
+     * 숫자의 왼쪽에 {source}로 채워 원하는 자릿수 만큼 세팅한다.
+     * @param original 원래 값
+     * @param digits 원하는 자릿수
+     * @return 세팅된 값
+     */
+    public static String padLeftValueWithZeros(String original, String source, int digits) {
+        String format = "%" + digits + "s";
+        return String.format(format, original).replace(" ", source);
+    }
+}

--- a/src/main/java/com/devspacehub/ast/domain/mashup/service/MashupService.java
+++ b/src/main/java/com/devspacehub/ast/domain/mashup/service/MashupService.java
@@ -67,12 +67,15 @@ public class MashupService {
     public void startOrderConclusionResultProcess(OpenApiType openApiType) {
         oAuthService.setAccessToken(TokenType.AccessToken);
         MyService myServiceImpl = myServiceImpl(openApiType);
+        LocalDate today = LocalDate.now();
 
         // 체결 상태 확인
-        List<OrderConclusionDto> concludedOrderTradingResults = myServiceImpl.getConcludedStock(LocalDate.now());
+        List<OrderConclusionDto> concludedOrderTradingResults = myServiceImpl.getConcludedStock(today);
+        log.info("{} API 호출 완료. 총 매수 체결 갯수 : {} 개", openApiType.getDiscription(), concludedOrderTradingResults.size());
+
         for (OrderConclusionDto orderConclusion : concludedOrderTradingResults) {
-            // 예약 매수 종목인 경우 처리
-            myServiceImpl.updateMyReservationOrderUseYn(orderConclusion, LocalDate.now());
+            // 종목 매수 예약 데이터 업데이트
+            myServiceImpl.updateMyReservationOrderUseYn(orderConclusion, today);
 
             // 체결된 종목들에 대해 디스코드 메시지 전달
             notificator.sendMessage(MessageContentDto.ConclusionResult.fromOne(openApiType, getAccountStatus(), orderConclusion));

--- a/src/main/java/com/devspacehub/ast/domain/my/dto/orderConclusion/DomesticOrderConclusionFindExternalResDto.java
+++ b/src/main/java/com/devspacehub/ast/domain/my/dto/orderConclusion/DomesticOrderConclusionFindExternalResDto.java
@@ -11,6 +11,7 @@ package com.devspacehub.ast.domain.my.dto.orderConclusion;
 import com.devspacehub.ast.common.dto.WebClientCommonResDto;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.micrometer.common.util.StringUtils;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -164,5 +165,21 @@ public class DomesticOrderConclusionFindExternalResDto extends WebClientCommonRe
     @Override
     public boolean isSuccess() {
         return !Objects.isNull(output1) && !Objects.isNull(output2) && OPENAPI_SUCCESS_RESULT_CODE.equals(this.resultCode);
+    }
+
+    /**
+     * 응답 필드 ctxAreaFk100 Getter
+     * @return 값의 양옆 공백 제거된 숫자
+     */
+    public String getCtxAreaFk100() {
+        return StringUtils.isBlank(this.ctxAreaFk100) ? "" : this.ctxAreaFk100.trim();
+    }
+
+    /**
+     * 응답 필드 ctxAreaNk100 Getter
+     * @return 값의 양옆 공백 제거된 숫자
+     */
+    public String getCtxAreaNk100() {
+        return StringUtils.isBlank(this.ctxAreaNk100) ? "" : this.ctxAreaNk100.trim();
     }
 }

--- a/src/main/java/com/devspacehub/ast/domain/my/dto/orderConclusion/DomesticOrderConclusionFindExternalResDto.java
+++ b/src/main/java/com/devspacehub/ast/domain/my/dto/orderConclusion/DomesticOrderConclusionFindExternalResDto.java
@@ -22,17 +22,18 @@ import java.util.Objects;
 import static com.devspacehub.ast.common.constant.CommonConstants.OPENAPI_SUCCESS_RESULT_CODE;
 
 /**
- * 주식 일별 주문 체결 조회 응답 DTO.
+ * 국내 주식 일별 주문 체결 조회 응답 DTO.
  */
 @Setter
-public class OrderConclusionFindExternalResDto extends WebClientCommonResDto {
+@Getter
+public class DomesticOrderConclusionFindExternalResDto extends WebClientCommonResDto {
 
     @JsonProperty("ctx_area_fk100")
     private String ctxAreaFk100;
 
     @JsonProperty("ctx_area_nk100")
     private String ctxAreaNk100;
-    @Getter
+
     @JsonProperty("output1")
     private List<Output1> output1;
 

--- a/src/main/java/com/devspacehub/ast/domain/my/dto/orderConclusion/OrderConclusionDto.java
+++ b/src/main/java/com/devspacehub/ast/domain/my/dto/orderConclusion/OrderConclusionDto.java
@@ -9,6 +9,7 @@
 package com.devspacehub.ast.domain.my.dto.orderConclusion;
 
 import com.devspacehub.ast.common.constant.OpenApiType;
+import com.devspacehub.ast.common.utils.NumberUtils;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -35,23 +36,48 @@ public class OrderConclusionDto {
     /**
      * 팩토리 메서드
      * @param responseBodies 주문 체결 조회 응답 DTO
-     * @return
+     * @return 국내 체결 결과 Dto 묶음
      */
-    public static List<OrderConclusionDto> of (List<OrderConclusionFindExternalResDto.Output1> responseBodies) {
+    public static List<OrderConclusionDto> domesticOf(List<DomesticOrderConclusionFindExternalResDto.Output1> responseBodies) {
         List<OrderConclusionDto> orderTradingResults = new ArrayList<>();
-        for (OrderConclusionFindExternalResDto.Output1 output1 : responseBodies) {
+        for (DomesticOrderConclusionFindExternalResDto.Output1 output1 : responseBodies) {
             orderTradingResults.add(OrderConclusionDto.builder()
-                            .itemCode(output1.getItemCode())
-                            .itemNameKor(output1.getItemNameKor())
-                            .orderNumber(output1.getOrderNumber())
-                            .concludedPrice(new BigDecimal(output1.getTotalConcludedPrice()))
-                            .concludedQuantity(Integer.parseInt(output1.getTotalConcludedQuantity()))
-                            .orderType(OpenApiType.DOMESTIC_ORDER_CONCLUSION_FIND)
-                            .orderQuantity(Integer.parseInt(output1.getOrderQuantity()))
-                            .orderPrice(new BigDecimal(output1.getOrderPrice()))
-                            .orderTime(output1.getOrderTime())
+                    .itemCode(output1.getItemCode())
+                    .itemNameKor(output1.getItemNameKor())
+                    .orderNumber(NumberUtils.padLeftValueWithZeros(output1.getOrderNumber(), "0", 10))
+                    .concludedPrice(new BigDecimal(output1.getTotalConcludedPrice()))
+                    .concludedQuantity(Integer.parseInt(output1.getTotalConcludedQuantity()))
+                    .orderType(OpenApiType.DOMESTIC_ORDER_CONCLUSION_FIND)
+                    .orderQuantity(Integer.parseInt(output1.getOrderQuantity()))
+                    .orderPrice(new BigDecimal(output1.getOrderPrice()))
+                    .orderTime(output1.getOrderTime())
                     .build());
         }
         return orderTradingResults;
     }
+
+    /**
+     * 팩토리 메서드
+     * @param responseBodies 주문 체결 조회 응답 DTO
+     * @return 해외 체결 결과 Dto 묶음
+     */
+    public static List<OrderConclusionDto> overseasOf(List<OverseasOrderConclusionFindExternalResDto.Output> responseBodies) {
+        List<OrderConclusionDto> orderTradingResults = new ArrayList<>();
+        for (OverseasOrderConclusionFindExternalResDto.Output output : responseBodies) {
+            orderTradingResults.add(OrderConclusionDto.builder()
+                    .itemCode(output.getItemCode())
+                    .itemNameKor(output.getItemNameKor())
+                    .orderNumber(NumberUtils.padLeftValueWithZeros(output.getOrderNumber(), "0", 10))
+                    .concludedPrice(new BigDecimal(output.getTotalConcludedPrice()))
+                    .concludedQuantity(Integer.parseInt(output.getTotalConcludedQuantity()))
+                    .orderType(OpenApiType.OVERSEAS_ORDER_CONCLUSION_FIND)
+                    .orderQuantity(Integer.parseInt(output.getOrderQuantity()))
+                    .orderPrice(new BigDecimal(output.getOrderPrice()))
+                    .orderTime(output.getOrderTime())
+                    .build());
+
+        }
+        return orderTradingResults;
+    }
 }
+

--- a/src/main/java/com/devspacehub/ast/domain/my/dto/orderConclusion/OrderConclusionFindExternalReqDto.java
+++ b/src/main/java/com/devspacehub/ast/domain/my/dto/orderConclusion/OrderConclusionFindExternalReqDto.java
@@ -77,7 +77,7 @@ public class OrderConclusionFindExternalReqDto {
             queryParams.add("PDNO", "");              // 전 종목코드
             queryParams.add("ORD_STRT_DT", todayStr);
             queryParams.add("ORD_END_DT", todayStr);
-            queryParams.add("SLL_BUY_DVSNS", "03");    // 매도매수구분코드 (02:매수)
+            queryParams.add("SLL_BUY_DVSN", "02");    // 매도매수구분코드 (02:매수)
             queryParams.add("CCLD_NCCS_DVSN", "01");  // 체결 구분 (01:체결)
             queryParams.add("OVRS_EXCG_CD", "%");     // 해외 거래소 코드. 모의에서는 전체조회("")만 가능. 실전에서는?
             queryParams.add("SORT_SQN", "DS");        // 정렬 순서 (DS:정순)

--- a/src/main/java/com/devspacehub/ast/domain/my/dto/orderConclusion/OrderConclusionFindExternalReqDto.java
+++ b/src/main/java/com/devspacehub/ast/domain/my/dto/orderConclusion/OrderConclusionFindExternalReqDto.java
@@ -13,32 +13,10 @@ import org.springframework.http.MediaType;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
-import java.util.function.Consumer;
-
 /**
  * 주식 일별 주문 체결 조회 요청 DTO.
  */
 public class OrderConclusionFindExternalReqDto {
-
-    public static MultiValueMap<String, String> createParameter(String accntNumber, String accntProductCode, String todayStr) {
-        MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
-        queryParams.add("CANO", accntNumber);
-        queryParams.add("ACNT_PRDT_CD", accntProductCode);
-        queryParams.add("INQR_STRT_DT", todayStr);  // 조회 시작 일자
-        queryParams.add("INQR_END_DT", todayStr);   // 조회 종료 일자
-        queryParams.add("SLL_BUY_DVSN_CD", "02");   // 매도매수구분코드 (02:매수)
-        queryParams.add("INQR_DVSN", "01");     // 조회 구분 (01:정순)
-        queryParams.add("PDNO", "");            // 종콕코드
-        queryParams.add("CCLD_DVSN", "01");     // 체결 구분
-        queryParams.add("ORD_GNO_BRNO", "");    // 주문채번지점번호
-        queryParams.add("ODNO", "");            // 주문번호
-        queryParams.add("INQR_DVSN_3", "01");   // 조회구분3 (01:현금)
-        queryParams.add("INQR_DVSN_1", "");     // 조회구분1 (1:ELW, 2:프리보드)
-        queryParams.add("CTX_AREA_FK100", "");   // 연속조회검색조건100
-        queryParams.add("CTX_AREA_NK100", "");   // 연속조회키100
-
-        return queryParams;
-    }
 
     /**
      * Sets headers.
@@ -47,11 +25,69 @@ public class OrderConclusionFindExternalReqDto {
      * @param txId  the tx id
      * @return the headers
      */
-    public static Consumer<HttpHeaders> setHeaders(String oauth, String txId) {
+    public static HttpHeaders setHeaders(String oauth, String txId) {
         HttpHeaders headers = new HttpHeaders();
         headers.add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
         headers.add(HttpHeaders.AUTHORIZATION, "Bearer " + oauth);
         headers.add("tr_id", txId);
-        return httpHeaders -> httpHeaders.addAll(headers);
+        return headers;
+    }
+
+    public static class Domestic {
+        /**
+         * 매수 주문의 체결 결과 조회 위해 파라미터 생성한다.
+         * @param accntNumber 계좌번호 앞 8자리
+         * @param accntProductCode 계좌번호 뒤 2자리
+         * @param todayStr 조회 일자 (yyyyMMdd)
+         * @return 파라미터
+         */
+        public static MultiValueMap<String, String> createParameter(String accntNumber, String accntProductCode, String todayStr) {
+            MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
+            queryParams.add("CANO", accntNumber);
+            queryParams.add("ACNT_PRDT_CD", accntProductCode);
+            queryParams.add("INQR_STRT_DT", todayStr);  // 조회 시작 일자
+            queryParams.add("INQR_END_DT", todayStr);   // 조회 종료 일자
+            queryParams.add("SLL_BUY_DVSN_CD", "02");   // 매도매수구분코드 (02:매수)
+            queryParams.add("INQR_DVSN", "01");         // 조회 구분 (01:정순)
+            queryParams.add("PDNO", "");                // 전 종목코드
+            queryParams.add("CCLD_DVSN", "01");         // 체결 구분
+            queryParams.add("ORD_GNO_BRNO", "");        // 주문채번지점번호
+            queryParams.add("ODNO", "");                // 주문번호
+            queryParams.add("INQR_DVSN_3", "01");       // 조회구분3 (01:현금)
+            queryParams.add("INQR_DVSN_1", "");         // 조회구분1 (1:ELW, 2:프리보드)
+            queryParams.add("CTX_AREA_FK100", "");      // 연속조회검색조건100
+            queryParams.add("CTX_AREA_NK100", "");      // 연속조회키100
+
+            return queryParams;
+        }
+    }
+
+    public static class Overseas {
+        /**
+         * 매수 주문의 체결 결과 조회 위해 파라미터 생성한다.
+         * @param accntNumber 계좌번호 앞 8자리
+         * @param accntProductCode 계좌번호 뒤 2자리
+         * @param todayStr 조회 일자 (YYYYMMDD)
+         * @return 파라미터
+         */
+        public static MultiValueMap<String, String> createParameter(String accntNumber, String accntProductCode, String todayStr) {
+            MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
+            queryParams.add("CANO", accntNumber);
+            queryParams.add("ACNT_PRDT_CD", accntProductCode);
+            queryParams.add("PDNO", "");              // 전 종목코드
+            queryParams.add("ORD_STRT_DT", todayStr);
+            queryParams.add("ORD_END_DT", todayStr);
+            queryParams.add("SLL_BUY_DVSNS", "03");    // 매도매수구분코드 (02:매수)
+            queryParams.add("CCLD_NCCS_DVSN", "01");  // 체결 구분 (01:체결)
+            queryParams.add("OVRS_EXCG_CD", "%");     // 해외 거래소 코드. 모의에서는 전체조회("")만 가능. 실전에서는?
+            queryParams.add("SORT_SQN", "DS");        // 정렬 순서 (DS:정순)
+            queryParams.add("ORD_DT", "");
+            queryParams.add("ORD_GNO_BRNO", "");
+            queryParams.add("ODNO", "");              // 주문번호
+            queryParams.add("CTX_AREA_FK200", "");    // 연속조회검색조건200
+            queryParams.add("CTX_AREA_NK200", "");    // 연속조회키200
+
+            return queryParams;
+        }
     }
 }

--- a/src/main/java/com/devspacehub/ast/domain/my/dto/orderConclusion/OverseasOrderConclusionFindExternalResDto.java
+++ b/src/main/java/com/devspacehub/ast/domain/my/dto/orderConclusion/OverseasOrderConclusionFindExternalResDto.java
@@ -1,0 +1,157 @@
+/*
+ © 2024 devspacehub, Inc. All rights reserved.
+
+ name : OverseasOrderConclusionFindExternalResDto
+ creation : 2024.8.15
+ author : Yoonji Moon
+ */
+
+package com.devspacehub.ast.domain.my.dto.orderConclusion;
+
+import com.devspacehub.ast.common.dto.WebClientCommonResDto;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.micrometer.common.util.StringUtils;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+import java.util.Objects;
+
+import static com.devspacehub.ast.common.constant.CommonConstants.OPENAPI_SUCCESS_RESULT_CODE;
+
+/**
+ * 해외 주식 주문체결내역 조회 응답 DTO.
+ */
+@Setter
+@Getter
+public class OverseasOrderConclusionFindExternalResDto extends WebClientCommonResDto {
+
+    @JsonProperty("ctx_area_nk200")
+    private String ctxAreaNk200;
+
+    @JsonProperty("ctx_area_fk200")
+    private String ctxAreaFk200;
+
+    @JsonProperty("output")
+    private List<Output> output;
+
+
+    /**
+     * API 응답이 성공인지 확인한다.
+     * @return 성공 응답이면 true, 실패 응답이면 false
+     */
+    @Override
+    public boolean isSuccess() {
+        return !Objects.isNull(output) && OPENAPI_SUCCESS_RESULT_CODE.equals(this.resultCode);
+    }
+
+    /**
+     * 응답 필드 ctxAreaFk200 Getter
+     * @return 값의 양옆 공백 제거된 숫자
+     */
+    public String getCtxAreaFk200() {
+        return StringUtils.isBlank(this.ctxAreaFk200) ? "" : this.ctxAreaFk200.trim();
+    }
+
+    /**
+     * 응답 필드 ctxAreaNk200 Getter
+     * @return 값의 양옆 공백 제거된 숫자
+     */
+    public String getCtxAreaNk200() {
+        return StringUtils.isBlank(this.ctxAreaNk200) ? "" : this.ctxAreaNk200.trim();
+    }
+
+    @Getter
+    public static class Output {
+
+        @JsonProperty("ord_dt")
+        private String ordDt;
+
+        @JsonProperty("ord_gno_brno")
+        private String ordGnoBrno;
+
+        @JsonProperty("odno")
+        private String orderNumber;
+
+        @JsonProperty("orgn_odno")
+        private String orgnOdno;
+
+        @JsonProperty("sll_buy_dvsn_cd")
+        private String sllBuyDvsnCd;
+
+        @JsonProperty("sll_buy_dvsn_cd_name")
+        private String sllBuyDvsnCdName;
+
+        @JsonProperty("rvse_cncl_dvsn")
+        private String rvseCnclDvsn;
+
+        @JsonProperty("rvse_cncl_dvsn_name")
+        private String rvseCnclDvsnName;
+
+        @JsonProperty("pdno")
+        private String itemCode;    // 종목 코드
+
+        @JsonProperty("prdt_name")
+        private String itemNameKor;    // 국문 종목명
+
+        @JsonProperty("ft_ord_qty")
+        private String orderQuantity;        // 주문 수량
+
+        @JsonProperty("ft_ord_unpr3")
+        private String orderPrice;          // 주문 가격
+
+        @JsonProperty("ft_ccld_qty")
+        private String totalConcludedQuantity;  // 체결 수량
+
+        @JsonProperty("ft_ccld_unpr3")
+        private String ftCcldUnpr3;      // 단가
+
+        @JsonProperty("ft_ccld_amt3")
+        private String totalConcludedPrice;       // 체결된 총 금액 (단가 * 체결 수량)
+
+        @JsonProperty("nccs_qty")
+        private String nccsQty;
+
+        @JsonProperty("prcs_stat_name")
+        private String prcsStatName;
+
+        @JsonProperty("rjct_rson")
+        private String rjctRson;
+
+        @JsonProperty("rjct_rson_name")
+        private String rjctRsonName;
+
+        @JsonProperty("ord_tmd")
+        private String orderTime;
+
+        @JsonProperty("tr_mket_name")
+        private String trMketName;
+
+        @JsonProperty("tr_natn")
+        private String trNatn;
+
+        @JsonProperty("tr_natn_name")
+        private String trNatnName;
+
+        @JsonProperty("ovrs_excg_cd")
+        private String ovrsExcgCd;
+
+        @JsonProperty("tr_crcy_cd")
+        private String trCrcyCd;
+
+        @JsonProperty("dmst_ord_dt")
+        private String dmstOrdDt;
+
+        @JsonProperty("thco_ord_tmd")
+        private String thcoOrdTmd;
+
+        @JsonProperty("loan_type_cd")
+        private String loanTypeCd;
+
+        @JsonProperty("loan_dt")
+        private String loanDt;
+
+        @JsonProperty("mdia_dvsn_name")
+        private String mdiaDvsnName;
+    }
+}

--- a/src/main/java/com/devspacehub/ast/domain/my/reservationOrderInfo/ReservationOrderInfo.java
+++ b/src/main/java/com/devspacehub/ast/domain/my/reservationOrderInfo/ReservationOrderInfo.java
@@ -87,11 +87,10 @@ public class ReservationOrderInfo extends BaseEntity {
 
     /**
      * 주문 수량만큼 모두 체결됐는지 체크한다.
-     * @param concludedQuantity
-     * @return
+     * @return 희망하는 주문 수량과 체결 수량이 동일하면 True.
      */
-    public boolean checkTotalConcluded(int concludedQuantity) {
-        return this.orderQuantity == concludedQuantity;
+    public boolean checkTotalConcluded() {
+        return this.orderQuantity == this.conclusionQuantity;
     }
 
     /**

--- a/src/main/java/com/devspacehub/ast/domain/my/service/MyServiceImpl.java
+++ b/src/main/java/com/devspacehub/ast/domain/my/service/MyServiceImpl.java
@@ -167,7 +167,7 @@ public class MyServiceImpl extends MyService {
         }
 
         if (StringUtils.isNotBlank(response.getHeaders().getFirst(MORE_DATA_YN_HEADER_NAME)) && MORE_DATA_HEADER_FLAGS.contains(response.getHeaders().getFirst(MORE_DATA_YN_HEADER_NAME))) {
-            return callApiUntilDone(accumulatedResponses, openApiType, this.prepareHeadersForSequentialApiCalls(headers),
+            return this.callApiUntilDone(accumulatedResponses, openApiType, this.prepareHeadersForSequentialApiCalls(headers),
                     this.prepareParamsForSequentialApiCalls(queryParams, response.getBody().getCtxAreaNk100(), response.getBody().getCtxAreaFk100()));
         } else {
             return accumulatedResponses;

--- a/src/main/java/com/devspacehub/ast/domain/my/service/OverseasMyServiceImpl.java
+++ b/src/main/java/com/devspacehub/ast/domain/my/service/OverseasMyServiceImpl.java
@@ -35,6 +35,7 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Consumer;
 
 import static com.devspacehub.ast.common.constant.OpenApiType.*;
@@ -148,7 +149,7 @@ public class OverseasMyServiceImpl extends MyService {
         ResponseEntity<OverseasOrderConclusionFindExternalResDto> response =
                 (ResponseEntity<OverseasOrderConclusionFindExternalResDto>) openApiRequest.httpGetRequestWithExecute(openApiType, headers, queryParams);
 
-        if (response.getBody().isSuccess()) {
+        if (!Objects.isNull(response.getBody()) && response.getBody().isSuccess()) {
             log.info("[{}] 일부 데이터 갯수 : {} 개", openApiType.getDiscription(), response.getBody().getOutput().size());
             accumulatedResponses.addAll(response.getBody().getOutput());
         } else {

--- a/src/main/java/com/devspacehub/ast/domain/my/service/OverseasMyServiceImpl.java
+++ b/src/main/java/com/devspacehub/ast/domain/my/service/OverseasMyServiceImpl.java
@@ -10,7 +10,10 @@ package com.devspacehub.ast.domain.my.service;
 
 import com.devspacehub.ast.common.config.OpenApiProperties;
 import com.devspacehub.ast.common.constant.OpenApiType;
+import com.devspacehub.ast.common.utils.LogUtils;
 import com.devspacehub.ast.domain.my.dto.MyServiceRequestDto;
+import com.devspacehub.ast.domain.my.dto.orderConclusion.OrderConclusionFindExternalReqDto;
+import com.devspacehub.ast.domain.my.dto.orderConclusion.OverseasOrderConclusionFindExternalResDto;
 import com.devspacehub.ast.domain.my.reservationOrderInfo.ReservationOrderInfoRepository;
 import com.devspacehub.ast.domain.my.stockBalance.dto.request.OverseasBuyPossibleCashApiReqDto;
 import com.devspacehub.ast.domain.my.stockBalance.dto.request.OverseasStockBalanceApiReqDto;
@@ -19,19 +22,22 @@ import com.devspacehub.ast.domain.my.stockBalance.dto.response.overseas.Overseas
 import com.devspacehub.ast.domain.my.dto.orderConclusion.OrderConclusionDto;
 import com.devspacehub.ast.exception.error.OpenApiFailedResponseException;
 import com.devspacehub.ast.util.OpenApiRequest;
+import io.micrometer.common.util.StringUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.util.MultiValueMap;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 
-import static com.devspacehub.ast.common.constant.OpenApiType.OVERSEAS_BUY_ORDER_POSSIBLE_CASH;
-import static com.devspacehub.ast.common.constant.OpenApiType.OVERSEAS_STOCK_BALANCE;
+import static com.devspacehub.ast.common.constant.OpenApiType.*;
 
 /**
  * 해외 주식 - My 기능 서비스 구현체 클래스
@@ -40,33 +46,32 @@ import static com.devspacehub.ast.common.constant.OpenApiType.OVERSEAS_STOCK_BAL
 @Slf4j
 @Service
 public class OverseasMyServiceImpl extends MyService {
-    private final OpenApiRequest openApiRequest;
-    private final OpenApiProperties openApiProperties;
 
     @Value("${openapi.rest.header.transaction-id.overseas.buy-order-possible-cash-find}")
     private String txIdBuyOrderPossibleCashFind;
     @Value("${openapi.rest.header.transaction-id.overseas.stock-balance-find}")
     private String txIdStockBalanceFind;
 
+    @Value("${openapi.rest.header.transaction-id.overseas.order-conclusion-find}")
+    private String txIdOrderConclusionFind;
+
     public OverseasMyServiceImpl(ReservationOrderInfoRepository reservationOrderInfoRepository, OpenApiRequest openApiRequest,
                                  OpenApiProperties openApiProperties) {
-        super(reservationOrderInfoRepository);
-        this.openApiRequest = openApiRequest;
-        this.openApiProperties = openApiProperties;
+        super(reservationOrderInfoRepository, openApiRequest, openApiProperties);
     }
 
     /**
      * 매수 가능 금액 조회 (Get)
      * @param requestDto requestDto MyService Layer Request Dto
      * @param <T> MyserviceRequestDto를 상속하는 타입.
-     * @throws OpenApiFailedResponseException 성공 응답이 아닌 경우
      * @return 해외 주문 가능 현금
+     * @throws OpenApiFailedResponseException 성공 응답이 아닌 경우
      */
     @Override
     public <T extends MyServiceRequestDto> BigDecimal getBuyOrderPossibleCash(T requestDto) {
         Consumer<HttpHeaders> httpHeaders = OverseasBuyPossibleCashApiReqDto.setHeaders(openApiProperties.getOauth(), txIdBuyOrderPossibleCashFind);
         MultiValueMap<String, String> queryParams = OverseasBuyPossibleCashApiReqDto.createParameter(
-                openApiProperties.getAccntNumber(), openApiProperties.getAccntProductCode(), (MyServiceRequestDto.Overseas)requestDto);
+                openApiProperties.getAccntNumber(), openApiProperties.getAccntProductCode(), (MyServiceRequestDto.Overseas) requestDto);
 
         OverseasBuyPossibleCashApiResDto responseDto = (OverseasBuyPossibleCashApiResDto) openApiRequest.httpGetRequest(OVERSEAS_BUY_ORDER_POSSIBLE_CASH, httpHeaders, queryParams);
 
@@ -112,17 +117,63 @@ public class OverseasMyServiceImpl extends MyService {
      */
     @Override
     public List<OrderConclusionDto> getConcludedStock(LocalDate today) {
-        // TODO 추후 개발
-        return null;
+        HttpHeaders headers = OrderConclusionFindExternalReqDto.setHeaders(openApiProperties.getOauth(), txIdOrderConclusionFind);
+        MultiValueMap<String, String> queryParams = OrderConclusionFindExternalReqDto.Overseas.createParameter(
+                openApiProperties.getAccntNumber(), openApiProperties.getAccntProductCode(), today.format(DateTimeFormatter.ofPattern("YYYYMMdd")));
+
+        return OrderConclusionDto.overseasOf(this.callOrderConclusionGetApi(OVERSEAS_ORDER_CONCLUSION_FIND, headers, queryParams));
     }
 
     /**
-     * 해외 예약 매수 수량 만큼 모두 체결되면 사용 여부를 비활성화 한다.
-     * @param orderConclusion 체결 종목 조회 응답 Dto
-     * @param concludedDate 체결 일자
+     * 체결 내역 조회 API 호출 요청한다.
+     * 연쇄적으로 데이터 호출이 발생할 수 있다.
+     * @param openApiType Open Api 타입
+     * @param headers 요청 헤더
+     * @param queryParams 요청 쿼리 파라미터
+     * @return 체결 내역 조회 결과
+     */
+    protected List<OverseasOrderConclusionFindExternalResDto.Output> callOrderConclusionGetApi(OpenApiType openApiType, final HttpHeaders headers, MultiValueMap<String, String> queryParams) {
+        return this.callApiUntilDone(new ArrayList<>(), openApiType, headers, queryParams);
+    }
+
+    /**
+     * 연속 조회해야할 때까지 재귀적으로 호출 수행한다.
+     * @param accumulatedResponses 최종 응답 데이터들
+     * @param openApiType OpenApi 타입
+     * @param headers 요청 헤더
+     * @param queryParams 요청 파라미터
+     * @return 최종 응답 데이터들
+     */
+    private List<OverseasOrderConclusionFindExternalResDto.Output> callApiUntilDone(List<OverseasOrderConclusionFindExternalResDto.Output> accumulatedResponses, OpenApiType openApiType, final HttpHeaders headers, final MultiValueMap<String, String> queryParams) {
+        ResponseEntity<OverseasOrderConclusionFindExternalResDto> response =
+                (ResponseEntity<OverseasOrderConclusionFindExternalResDto>) openApiRequest.httpGetRequestWithExecute(openApiType, headers, queryParams);
+
+        if (response.getBody().isSuccess()) {
+            log.info("[{}] 일부 데이터 갯수 : {} 개", openApiType.getDiscription(), response.getBody().getOutput().size());
+            accumulatedResponses.addAll(response.getBody().getOutput());
+        } else {
+            LogUtils.openApiFailedResponseMessage(openApiType, response.getBody().getMessage(), response.getBody().getMessageCode());
+        }
+
+        if (StringUtils.isNotBlank(response.getHeaders().getFirst(MORE_DATA_YN_HEADER_NAME)) && MORE_DATA_HEADER_FLAGS.contains(response.getHeaders().getFirst(MORE_DATA_YN_HEADER_NAME))) {
+            return callApiUntilDone(accumulatedResponses, openApiType, this.prepareHeadersForSequentialApiCalls(headers),
+                    this.prepareParamsForSequentialApiCalls(queryParams, response.getBody().getCtxAreaNk200(), response.getBody().getCtxAreaFk200()));
+        } else {
+            return accumulatedResponses;
+        }
+    }
+
+    /**
+     * 연속 데이터 조회위해 추가 API 호출 위한 요청 파라미터 추가 세팅한다.
+     * @param queryParams 기존 쿼리 파라미터
+     * @param ctxAreaNk 연속조회키200
+     * @param ctxAreaFk 연속조회검색조건200
+     * @return 추가 세팅된 쿼리 파라미터
      */
     @Override
-    public void updateMyReservationOrderUseYn(OrderConclusionDto orderConclusion, LocalDate concludedDate) {
-        // TODO 추후 해외 예약 매수 개발 후 개발
+    protected MultiValueMap<String, String> prepareParamsForSequentialApiCalls(MultiValueMap<String, String> queryParams, String ctxAreaNk, String ctxAreaFk) {
+        queryParams.set("CTX_AREA_NK200", ctxAreaNk);
+        queryParams.set("CTX_AREA_FK200", ctxAreaFk);
+        return queryParams;
     }
 }

--- a/src/main/java/com/devspacehub/ast/domain/my/service/OverseasMyServiceImpl.java
+++ b/src/main/java/com/devspacehub/ast/domain/my/service/OverseasMyServiceImpl.java
@@ -120,7 +120,7 @@ public class OverseasMyServiceImpl extends MyService {
     public List<OrderConclusionDto> getConcludedStock(LocalDate today) {
         HttpHeaders headers = OrderConclusionFindExternalReqDto.setHeaders(openApiProperties.getOauth(), txIdOrderConclusionFind);
         MultiValueMap<String, String> queryParams = OrderConclusionFindExternalReqDto.Overseas.createParameter(
-                openApiProperties.getAccntNumber(), openApiProperties.getAccntProductCode(), today.format(DateTimeFormatter.ofPattern("YYYYMMdd")));
+                openApiProperties.getAccntNumber(), openApiProperties.getAccntProductCode(), today.format(DateTimeFormatter.ofPattern("yyyyMMdd")));
 
         return OrderConclusionDto.overseasOf(this.callOrderConclusionGetApi(OVERSEAS_ORDER_CONCLUSION_FIND, headers, queryParams));
     }

--- a/src/main/java/com/devspacehub/ast/domain/notification/Notificator.java
+++ b/src/main/java/com/devspacehub/ast/domain/notification/Notificator.java
@@ -65,8 +65,7 @@ public class Notificator {
             if (ex instanceof WebClientResponseException webClientResponseException && HttpStatus.NO_CONTENT.equals(webClientResponseException.getStatusCode())) {
                 return;
             }
-            log.error("response error: {}", ex.getMessage());
-            throw new NotificationException();
+            throw new NotificationException(ex.getMessage());
         }
     }
     /**
@@ -79,6 +78,7 @@ public class Notificator {
             case DOMESTIC_STOCK_BUY_ORDER, DOMESTIC_STOCK_SELL_ORDER, DOMESTIC_STOCK_RESERVATION_BUY_ORDER -> DOMESTIC_ORDER_NOTI_SENDER_NAME;
             case DOMESTIC_ORDER_CONCLUSION_FIND -> DOMESTIC_CONCLUSION_NOTI_SENDER_NAME;
             case OVERSEAS_STOCK_BUY_ORDER, OVERSEAS_STOCK_SELL_ORDER, OVERSEAS_STOCK_RESERVATION_BUY_ORDER -> OVERSEAS_ORDER_NOTI_SENDER_NAME;
+            case OVERSEAS_ORDER_CONCLUSION_FIND -> OVERSEAS_CONCLUSION_NOTI_SENDER_NAME;
             default -> throw new InvalidValueException(ResultCode.INVALID_OPENAPI_TYPE_ERROR);
         };
     }

--- a/src/main/java/com/devspacehub/ast/domain/orderTrading/OrderTrading.java
+++ b/src/main/java/com/devspacehub/ast/domain/orderTrading/OrderTrading.java
@@ -8,6 +8,7 @@
 
 package com.devspacehub.ast.domain.orderTrading;
 
+import com.devspacehub.ast.common.utils.NumberUtils;
 import com.devspacehub.ast.domain.marketStatus.dto.StockItemDto;
 import com.devspacehub.ast.domain.orderTrading.dto.StockOrderApiResDto;
 import jakarta.persistence.*;
@@ -80,7 +81,7 @@ public class OrderTrading extends BaseEntity {
                 .orderResultCode(result.getResultCode())
                 .orderMessageCode(result.getMessageCode())
                 .orderMessage(result.getMessage())
-                .orderNumber(result.isSuccess() ? result.getOutput().getOrderNumber() : null)
+                .orderNumber(result.isSuccess() ? NumberUtils.padLeftValueWithZeros(result.getOutput().getOrderNumber(), "0", 10) : null)
                 .orderTime(result.isSuccess() ? result.getOutput().getOrderTime() : null)
                 .build();
     }

--- a/src/main/java/com/devspacehub/ast/exception/error/NotificationException.java
+++ b/src/main/java/com/devspacehub/ast/exception/error/NotificationException.java
@@ -17,7 +17,7 @@ public class NotificationException extends BusinessException {
     /**
      * Instantiates a notification exception.
      */
-    public NotificationException() {
-        super(ResultCode.NOTIFICATION_ERROR);
+    public NotificationException(String message) {
+        super(ResultCode.NOTIFICATION_ERROR, message);
     }
 }

--- a/src/main/java/com/devspacehub/ast/exception/error/OpenApiFailedResponseException.java
+++ b/src/main/java/com/devspacehub/ast/exception/error/OpenApiFailedResponseException.java
@@ -22,7 +22,7 @@ public class OpenApiFailedResponseException extends BusinessException {
     public OpenApiFailedResponseException(String message) {
         super(ResultCode.OPENAPI_SERVER_RESPONSE_ERROR, message);
     }
-    public OpenApiFailedResponseException(OpenApiType openApiType, String exMessage) {
-        super(ResultCode.OPENAPI_SERVER_RESPONSE_ERROR, String.format("요청 실패하였습니다.(API : %s, Open Api Server Response Message: %s)", openApiType.getDiscription(), exMessage));
+    public OpenApiFailedResponseException(OpenApiType openApiType, String externalServerMessage) {
+        super(ResultCode.OPENAPI_SERVER_RESPONSE_ERROR, String.format("요청 실패하였습니다.(API : %s, Open Api Server Response Message: %s)", openApiType.getDiscription(), externalServerMessage));
     }
 }

--- a/src/main/resources/application-openapi.yml
+++ b/src/main/resources/application-openapi.yml
@@ -46,6 +46,7 @@ openapi:
           buy-order-possible-cash-find: VTTS3007R
           stock-balance-find: VTTS3012R
           stock-condition-search: HHDFS76410000
+          order-conclusion-find: VTTS3035R
     appkey: ${APP_KEY}
     appsecret: ${APP_SECRET}
 
@@ -89,6 +90,7 @@ openapi:
           stock-balance-find: TTTS3012R
           stock-condition-search: HHDFS76410000
           buy-order-possible-cash-find: TTTS3007R
+          order-conclusion-find: TTTS3035R
 
     appkey: ${APP_KEY}
     appSecret: ${APP_SECRET}

--- a/src/test/java/com/devspacehub/ast/domain/my/reservationOrderInfo/ReservationOrderInfoTest.java
+++ b/src/test/java/com/devspacehub/ast/domain/my/reservationOrderInfo/ReservationOrderInfoTest.java
@@ -48,4 +48,24 @@ class ReservationOrderInfoTest {
         // then
         assertThat(reservationOrderInfo.getOrderQuantity()).isEqualTo(7);
     }
+
+    @Test
+    @DisplayName("주문 희망 수량이 체결 수량과 동일한지 확인한다.")
+    void return_true_when_orderQuantity_is_equal_to_conclusionQuantity() {
+        ReservationOrderInfo given = ReservationOrderInfo.builder().orderQuantity(5).conclusionQuantity(5).build();
+
+        boolean result = given.checkTotalConcluded();
+
+        assertThat(result).isTrue();
+    }
+
+    @DisplayName("예약 매수 종목을 비활성화 처리한다.")
+    @Test
+    void disable_entity_by_setting_useYn_as_N() {
+        ReservationOrderInfo given = ReservationOrderInfo.builder().useYn('Y').build();
+
+        given.disable();
+
+        assertThat(given.getUseYn()).isEqualTo('N');
+    }
 }

--- a/src/test/java/com/devspacehub/ast/domain/my/service/MyServiceImplTest.java
+++ b/src/test/java/com/devspacehub/ast/domain/my/service/MyServiceImplTest.java
@@ -22,6 +22,7 @@ import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
 import java.time.LocalDate;
@@ -68,6 +69,18 @@ class MyServiceImplTest {
         // then
         assertNotNull(result);
         assertThat(result).hasSize(1);
-        assertThat(givenOpenApiResponseDto.getOutput1().get(0).getItemCode()).isEqualTo(result.get(0).getItemCode());
+        assertThat(result.get(0).getItemCode()).isEqualTo("000000");
+        assertThat(result.get(0).getOrderNumber()).isEqualTo("0000011111");
+    }
+
+    @DisplayName("연쇄적인 API 호출 시 요청 파라미터를 추가 세팅한다.")
+    @Test
+    void prepareParamsForSequentialApiCalls() {
+        MultiValueMap<String, String> result = myServiceImpl.prepareParamsForSequentialApiCalls(new LinkedMultiValueMap<>(), "100001", "200001");
+
+        assertThat(result)
+                .hasSize(2)
+                .containsEntry("CTX_AREA_NK100", List.of("100001"))
+                .containsEntry("CTX_AREA_FK100", List.of("200001"));
     }
 }

--- a/src/test/java/com/devspacehub/ast/domain/my/service/MyServiceImplTest.java
+++ b/src/test/java/com/devspacehub/ast/domain/my/service/MyServiceImplTest.java
@@ -10,7 +10,7 @@ package com.devspacehub.ast.domain.my.service;
 
 import com.devspacehub.ast.common.config.OpenApiProperties;
 import com.devspacehub.ast.common.constant.OpenApiType;
-import com.devspacehub.ast.domain.my.dto.orderConclusion.OrderConclusionFindExternalResDto;
+import com.devspacehub.ast.domain.my.dto.orderConclusion.DomesticOrderConclusionFindExternalResDto;
 import com.devspacehub.ast.domain.my.dto.orderConclusion.OrderConclusionDto;
 import com.devspacehub.ast.util.OpenApiRequest;
 import org.junit.jupiter.api.DisplayName;
@@ -20,11 +20,12 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
 import org.springframework.util.MultiValueMap;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.function.Consumer;
 
 import static com.devspacehub.ast.common.constant.CommonConstants.OPENAPI_SUCCESS_RESULT_CODE;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -46,9 +47,9 @@ class MyServiceImplTest {
     @Test
     void getConcludedStock() {
         // given
-        OrderConclusionFindExternalResDto givenOpenApiResponseDto = new OrderConclusionFindExternalResDto();
+        DomesticOrderConclusionFindExternalResDto givenOpenApiResponseDto = new DomesticOrderConclusionFindExternalResDto();
         givenOpenApiResponseDto.setResultCode(OPENAPI_SUCCESS_RESULT_CODE);
-        givenOpenApiResponseDto.setOutput1(List.of(OrderConclusionFindExternalResDto.Output1.builder()
+        givenOpenApiResponseDto.setOutput1(List.of(DomesticOrderConclusionFindExternalResDto.Output1.builder()
                 .itemCode("000000")
                 .itemNameKor("TEST")
                 .orderNumber("11111")
@@ -58,9 +59,9 @@ class MyServiceImplTest {
                 .orderPrice("1000")
                 .orderTime("090008")
                 .build()));
-        givenOpenApiResponseDto.setOutput2(new OrderConclusionFindExternalResDto.Output2());
+        givenOpenApiResponseDto.setOutput2(new DomesticOrderConclusionFindExternalResDto.Output2());
         given(openApiProperties.getOauth()).willReturn("oauth");
-        given(openApiRequest.httpGetRequest(any(OpenApiType.class), any(Consumer.class), any(MultiValueMap.class))).willReturn(givenOpenApiResponseDto);
+        given(openApiRequest.httpGetRequestWithExecute(any(OpenApiType.class), any(HttpHeaders.class), any(MultiValueMap.class))).willReturn(ResponseEntity.ok(givenOpenApiResponseDto));
 
         // when
         List<OrderConclusionDto> result = myServiceImpl.getConcludedStock(LocalDate.now());

--- a/src/test/java/com/devspacehub/ast/domain/orderTrading/dto/OrderConclusionDtoTest.java
+++ b/src/test/java/com/devspacehub/ast/domain/orderTrading/dto/OrderConclusionDtoTest.java
@@ -10,7 +10,7 @@ package com.devspacehub.ast.domain.orderTrading.dto;
 
 import com.devspacehub.ast.common.constant.OpenApiType;
 import com.devspacehub.ast.domain.my.dto.orderConclusion.OrderConclusionDto;
-import com.devspacehub.ast.domain.my.dto.orderConclusion.OrderConclusionFindExternalResDto;
+import com.devspacehub.ast.domain.my.dto.orderConclusion.DomesticOrderConclusionFindExternalResDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -27,27 +27,27 @@ class OrderConclusionDtoTest {
     void of() {
         // given
         OpenApiType givenOrderType = OpenApiType.DOMESTIC_ORDER_CONCLUSION_FIND;
-        OrderConclusionFindExternalResDto.Output1 firstGivenOutput1 = OrderConclusionFindExternalResDto.Output1.builder()
+        DomesticOrderConclusionFindExternalResDto.Output1 firstGivenOutput1 = DomesticOrderConclusionFindExternalResDto.Output1.builder()
                 .itemCode("00000")
                 .itemNameKor("테스트1")
-                .orderNumber("00000001")
+                .orderNumber("0000000001")
                 .totalConcludedPrice("1000")
                 .totalConcludedQuantity("1")
                 .orderQuantity("2")
                 .orderPrice("1000")
                 .build();
-        OrderConclusionFindExternalResDto.Output1 secondGivenOutput1 = OrderConclusionFindExternalResDto.Output1.builder()
+        DomesticOrderConclusionFindExternalResDto.Output1 secondGivenOutput1 = DomesticOrderConclusionFindExternalResDto.Output1.builder()
                 .itemCode("00001")
                 .itemNameKor("테스트2")
-                .orderNumber("00000002")
+                .orderNumber("0000000002")
                 .totalConcludedPrice("2000")
                 .totalConcludedQuantity("2")
                 .orderQuantity("3")
                 .orderPrice("2000")
                 .build();
-        List<OrderConclusionFindExternalResDto.Output1> givenOutput1s = List.of(firstGivenOutput1, secondGivenOutput1);
+        List<DomesticOrderConclusionFindExternalResDto.Output1> givenOutput1s = List.of(firstGivenOutput1, secondGivenOutput1);
         // when
-        List<OrderConclusionDto> results = OrderConclusionDto.of(givenOutput1s);
+        List<OrderConclusionDto> results = OrderConclusionDto.domesticOf(givenOutput1s);
         // then
         assertThat(results).hasSize(2)
                 .extracting(


### PR DESCRIPTION
1. 해외 주식 체결 결과 후처리 API
   - KIS '일자별 체결 결과 조회 API' 호출
   - 체결 결과 내역 중 예약 매수 주문에 의한 체결인 경우 예약 테이블의 칼럼 업데이트
   - 디스코드 메시지 발송
2. 단위 테스트코드 작성 
   -  기존 테스트 코드에 추가 검증 로직 추가, 요청 파라미터 세팅 메서드 > 테스트코드 추가
3. 국내/해외 체결결과내역조회 API 연쇄적으로 호출할 수 있도록 수정
4. 모의에서 국내/회의 매수 주문 API 응답 데이터와 체결결과내역조회 API 응답 데이터의 `orderNumber` 값을 좌측에 '0'을 채워넣어 10자릿수를 세팅하는 로직 추가하였음. ([참고](https://github.com/DevSpaceHub/AST/issues/58#issuecomment-2321049176))

#58 close