### PR TITLE
bugfix : 주문 체결내역 처리 프로세스 버그 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'com.devspacehub'
-version = '0.3.4'
+version = '0.3.5'
 
 java {
 	sourceCompatibility = '17'

--- a/src/main/java/com/devspacehub/ast/domain/my/dto/orderConclusion/OrderConclusionFindExternalReqDto.java
+++ b/src/main/java/com/devspacehub/ast/domain/my/dto/orderConclusion/OrderConclusionFindExternalReqDto.java
@@ -13,6 +13,9 @@ import org.springframework.http.MediaType;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
 /**
  * 주식 일별 주문 체결 조회 요청 DTO.
  */
@@ -67,19 +70,21 @@ public class OrderConclusionFindExternalReqDto {
          * 매수 주문의 체결 결과 조회 위해 파라미터 생성한다.
          * @param accntNumber 계좌번호 앞 8자리
          * @param accntProductCode 계좌번호 뒤 2자리
-         * @param todayStr 조회 일자 (YYYYMMDD)
+         * @param today 거래 종료 후 당일 일자
          * @return 파라미터
          */
-        public static MultiValueMap<String, String> createParameter(String accntNumber, String accntProductCode, String todayStr) {
+        public static MultiValueMap<String, String> createParameter(String accntNumber, String accntProductCode, LocalDate today) {
+            DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyyMMdd");
+
             MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
             queryParams.add("CANO", accntNumber);
             queryParams.add("ACNT_PRDT_CD", accntProductCode);
             queryParams.add("PDNO", "");              // 전 종목코드
-            queryParams.add("ORD_STRT_DT", todayStr);
-            queryParams.add("ORD_END_DT", todayStr);
+            queryParams.add("ORD_STRT_DT", today.minusDays(1).format(dateTimeFormatter));
+            queryParams.add("ORD_END_DT", today.format(dateTimeFormatter));
             queryParams.add("SLL_BUY_DVSN", "02");    // 매도매수구분코드 (02:매수)
             queryParams.add("CCLD_NCCS_DVSN", "01");  // 체결 구분 (01:체결)
-            queryParams.add("OVRS_EXCG_CD", "%");     // 해외 거래소 코드. 모의에서는 전체조회("")만 가능. 실전에서는?
+            queryParams.add("OVRS_EXCG_CD", "%");     // 해외 거래소 코드
             queryParams.add("SORT_SQN", "DS");        // 정렬 순서 (DS:정순)
             queryParams.add("ORD_DT", "");
             queryParams.add("ORD_GNO_BRNO", "");

--- a/src/main/java/com/devspacehub/ast/domain/my/reservationOrderInfo/service/OverseasReservationBuyOrderService.java
+++ b/src/main/java/com/devspacehub/ast/domain/my/reservationOrderInfo/service/OverseasReservationBuyOrderService.java
@@ -36,6 +36,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
 
 import java.math.BigDecimal;
@@ -54,6 +55,7 @@ import static com.devspacehub.ast.common.constant.ProfileType.getAccountStatus;
  * TradingService 구현체인, 해외 예약 주문 서비스
  */
 @Slf4j
+@Transactional(readOnly = true)
 @Service
 public class OverseasReservationBuyOrderService extends TradingService {
     private final ReservationOrderInfoRepository reservationOrderInfoRepository;
@@ -78,6 +80,7 @@ public class OverseasReservationBuyOrderService extends TradingService {
      * @param openApiType OpenApi 타입
      * @return 주문 완료한 종목 정보 List
      */
+    @Transactional
     @Override
     public List<OrderTrading> order(OpenApiProperties openApiProperties, OpenApiType openApiType) {
         List<ReservationStockItem> reservations = getValidReservationsForToday();
@@ -222,6 +225,7 @@ public class OverseasReservationBuyOrderService extends TradingService {
      * @param orderTradingInfos List 타입의 주문 완료된 OrderTrading Entity
      * @return 테이브에 저장 완료된 List 타입의 OrderTrading Entity
      */
+    @Transactional
     @Override
     public List<OrderTrading> saveOrderInfos(List<OrderTrading> orderTradingInfos) {
         if (orderTradingInfos.isEmpty()) {
@@ -252,6 +256,7 @@ public class OverseasReservationBuyOrderService extends TradingService {
      * @param result 주문 OpenApi 응답 Dto
      * @param reservationItemSeq 예약 종목 Seq
      */
+    @Transactional
     public void updateLatestOrderNumber(StockOrderApiResDto result, Long reservationItemSeq) {
         if (result.isFailed()) {
             return;

--- a/src/main/java/com/devspacehub/ast/domain/my/reservationOrderInfo/service/ReservationBuyOrderServiceImpl.java
+++ b/src/main/java/com/devspacehub/ast/domain/my/reservationOrderInfo/service/ReservationBuyOrderServiceImpl.java
@@ -75,6 +75,7 @@ public class ReservationBuyOrderServiceImpl extends TradingService {
      * @param openApiType
      * @return
      */
+    @Transactional
     @Override
     public List<OrderTrading> order(OpenApiProperties openApiProperties, OpenApiType openApiType) {
         // 1. 예약 종목들 조회
@@ -112,6 +113,7 @@ public class ReservationBuyOrderServiceImpl extends TradingService {
      * @param result 주문 OpenApi 응답 Dto
      * @param reservationItemSeq 예약 종목 Seq
      */
+    @Transactional
     public void updateLatestOrderNumber(StockOrderApiResDto result, Long reservationItemSeq) {
         if (result.isFailed()) {
             return;

--- a/src/main/java/com/devspacehub/ast/domain/my/service/OverseasMyServiceImpl.java
+++ b/src/main/java/com/devspacehub/ast/domain/my/service/OverseasMyServiceImpl.java
@@ -120,7 +120,7 @@ public class OverseasMyServiceImpl extends MyService {
     public List<OrderConclusionDto> getConcludedStock(LocalDate today) {
         HttpHeaders headers = OrderConclusionFindExternalReqDto.setHeaders(openApiProperties.getOauth(), txIdOrderConclusionFind);
         MultiValueMap<String, String> queryParams = OrderConclusionFindExternalReqDto.Overseas.createParameter(
-                openApiProperties.getAccntNumber(), openApiProperties.getAccntProductCode(), today.format(DateTimeFormatter.ofPattern("yyyyMMdd")));
+                openApiProperties.getAccntNumber(), openApiProperties.getAccntProductCode(), today);
 
         return OrderConclusionDto.overseasOf(this.callOrderConclusionGetApi(OVERSEAS_ORDER_CONCLUSION_FIND, headers, queryParams));
     }

--- a/src/test/java/com/devspacehub/ast/domain/my/dto/orderConclusion/OrderConclusionFindExternalReqDtoTest.java
+++ b/src/test/java/com/devspacehub/ast/domain/my/dto/orderConclusion/OrderConclusionFindExternalReqDtoTest.java
@@ -1,0 +1,31 @@
+/*
+ © 2024 devspacehub, Inc. All rights reserved.
+
+ name : OrderConclusionFindExternalReqDtoTest
+ creation : 2024.9.5
+ author : Yoonji Moon
+ */
+package com.devspacehub.ast.domain.my.dto.orderConclusion;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.util.MultiValueMap;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OrderConclusionFindExternalReqDtoTest {
+
+    @DisplayName("해외 주식은 장 시작 일자가 종료 일자보다 하루 전으로 세팅되어야 한다.")
+    @Test
+    void startDate_is_one_day_earlier_than_endDate_only_Overseas() {
+        LocalDate given = LocalDate.of(2024, 9, 5);
+
+        MultiValueMap<String, String> result = OrderConclusionFindExternalReqDto.Overseas.createParameter("12345678", "01", given);
+
+        assertThat(result.get("ORD_STRT_DT").get(0)).isEqualTo("20240904");
+        assertThat(result.get("ORD_END_DT").get(0)).isEqualTo("20240905");
+    }
+
+}


### PR DESCRIPTION
- 해외- 체결내역 조회 시 주문 시작일자와 주문 종료일자가 하루 차이 난다.
- 트랜잭션 ReadOnly 설정으로 인해 업데이트 쿼리문이 수행되지 않은 이슈 해결
  - Read 쿼리문만을 포함하는 메서드는 readOnly 옵션이 적용되도록 함.