### PR TITLE
bugfix : 주문번호가 수정된 엔티티를 전달하도록 수정 +refactor

### DIFF
--- a/src/main/java/com/devspacehub/ast/domain/orderTrading/service/TradingService.java
+++ b/src/main/java/com/devspacehub/ast/domain/orderTrading/service/TradingService.java
@@ -54,12 +54,9 @@ public abstract class TradingService {
 
     /**
      * OpenAPI 매수/매도 주문 요청의 응답에 대한 결과 처리<br>
-     * - 성공 -> 메세지 발송<br>
-     * - 실패 -> 에러 로그
-     * @param result 매수/매도 주문 응답 Dto
      * @param orderTrading 종목 정보 Dto
      */
-    public abstract <T extends WebClientCommonResDto> void orderApiResultProcess(T result, OrderTrading orderTrading);
+    public abstract void orderApiResultProcess(OrderTrading orderTrading);
 
 
     /**

--- a/src/main/java/com/devspacehub/ast/domain/orderTrading/service/overseas/OverseasSellOrderServiceImpl.java
+++ b/src/main/java/com/devspacehub/ast/domain/orderTrading/service/overseas/OverseasSellOrderServiceImpl.java
@@ -11,7 +11,6 @@ package com.devspacehub.ast.domain.orderTrading.service.overseas;
 import com.devspacehub.ast.common.config.OpenApiProperties;
 import com.devspacehub.ast.common.constant.MarketType;
 import com.devspacehub.ast.common.constant.OpenApiType;
-import com.devspacehub.ast.common.dto.WebClientCommonResDto;
 import com.devspacehub.ast.common.utils.LogUtils;
 import com.devspacehub.ast.domain.marketStatus.dto.StockItemDto;
 import com.devspacehub.ast.domain.my.service.MyService;
@@ -24,6 +23,8 @@ import com.devspacehub.ast.domain.orderTrading.OrderTradingRepository;
 import com.devspacehub.ast.domain.orderTrading.dto.OverseasStockOrderApiReqDto;
 import com.devspacehub.ast.domain.orderTrading.dto.StockOrderApiResDto;
 import com.devspacehub.ast.domain.orderTrading.service.TradingService;
+import com.devspacehub.ast.exception.error.BusinessException;
+import com.devspacehub.ast.exception.error.OpenApiFailedResponseException;
 import com.devspacehub.ast.util.OpenApiRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -77,14 +78,34 @@ public class OverseasSellOrderServiceImpl extends TradingService {
 
         // 2. 주식 선택 후 매도 주문 (손절매도 & 수익매도)
         List<OrderTrading> orderTradings = new ArrayList<>();
+        OrderTrading orderTrading;
         for (StockItemDto.Overseas item : pickStockItems(myStockBalance)) {
-            StockOrderApiResDto result = callOrderApi(openApiProperties, item, OVERSEAS_STOCK_SELL_ORDER, transactionId);
-            OrderTrading orderTrading = OrderTrading.from(item, result, transactionId);
+            try {
+                orderTrading = this.buy(item, openApiProperties, openApiType);
+            } catch(BusinessException ex) {
+                log.warn("code = {}, message = '{}'", ex.getResultCode(), ex.getMessage());
+                continue;
+            }
             orderTradings.add(orderTrading);
-
-            orderApiResultProcess(result, orderTrading);
+            this.orderApiResultProcess(orderTrading);
         }
         return orderTradings;
+    }
+    /**
+     * 매수 주문하고 결과 값을 Entity로 변환하여 반환한다.
+     * @param item 요청 파라미터
+     * @param openApiProperties OpenApi 요청 프로퍼티
+     * @param openApiType  OpenApi 요청 타입
+     * @return OrderTrading 타입의 주문 데이터
+     * @throws OpenApiFailedResponseException OpenApi 실패 응답인 경우
+     */
+    private OrderTrading buy(StockItemDto.Overseas item, OpenApiProperties openApiProperties, OpenApiType openApiType) {
+        StockOrderApiResDto apiResponse = callOrderApi(openApiProperties, item, openApiType, transactionId);
+        if (apiResponse.isFailed()) {
+            throw new OpenApiFailedResponseException(openApiType, apiResponse.getMessage());
+        }
+
+        return OrderTrading.from(item, apiResponse, transactionId);
     }
 
     /**
@@ -164,20 +185,12 @@ public class OverseasSellOrderServiceImpl extends TradingService {
 
     /**
      * 매도 주문 후 로그 출력 및 메세지 전송 요청
-     *
-     * @param result       주문 결과 Dto
      * @param orderTrading 매도 주문 정보 Entity
-     * @param <T>          WebClientCommonResDto를 상속하는 클래스
      */
     @Override
-    public <T extends WebClientCommonResDto> void orderApiResultProcess(T result, OrderTrading orderTrading) {
-        if (result.isSuccess()) {
-            LogUtils.tradingOrderSuccess(OVERSEAS_STOCK_SELL_ORDER, orderTrading.getItemNameKor());
-            notificator.sendMessage(MessageContentDto.OrderResult.fromOne(
-                    OVERSEAS_STOCK_SELL_ORDER, getAccountStatus(), orderTrading));
-        } else {
-            LogUtils.openApiFailedResponseMessage(OVERSEAS_STOCK_SELL_ORDER, result.getMessage(), result.getMessageCode());
-        }
+    public void orderApiResultProcess(OrderTrading orderTrading) {
+        LogUtils.tradingOrderSuccess(OVERSEAS_STOCK_SELL_ORDER, orderTrading.getItemNameKor());
+        notificator.sendMessage(MessageContentDto.OrderResult.fromOne(OVERSEAS_STOCK_SELL_ORDER, getAccountStatus(), orderTrading));
     }
 
     private MyService myServiceImpl() {

--- a/src/test/java/com/devspacehub/ast/domain/my/reservationOrderInfo/service/ReservationBuyOrderServiceIntegrationTest.java
+++ b/src/test/java/com/devspacehub/ast/domain/my/reservationOrderInfo/service/ReservationBuyOrderServiceIntegrationTest.java
@@ -138,15 +138,10 @@ class ReservationBuyOrderServiceIntegrationTest {
                 .orderNumber(givenOldOrderNumber)
                 .build();
         ReservationOrderInfo save = reservationOrderInfoRepository.save(given);
-
-        StockOrderApiResDto givenApiResult = new StockOrderApiResDto();
-        StockOrderApiResDto.Output givenOutput = new StockOrderApiResDto.Output();
-        givenApiResult.setResultCode(OPENAPI_SUCCESS_RESULT_CODE);
-        givenOutput.setOrderNumber(givenNewOrderNumber);
-        givenApiResult.setOutput(givenOutput);
+        OrderTrading givenOrderEntity = OrderTrading.builder().orderNumber(givenNewOrderNumber).build();
 
         // when
-        reservationBuyOrderService.updateLatestOrderNumber(givenApiResult, save.getSeq());
+        reservationBuyOrderService.updateLatestOrderNumber(givenOrderEntity, save.getSeq());
         // then
         ReservationOrderInfo result = reservationOrderInfoRepository.findById(save.getSeq()).orElseThrow();
         assertThat(result.getOrderNumber()).isEqualTo(givenNewOrderNumber);


### PR DESCRIPTION
bugfix : 주문번호가 수정된 엔티티를 전달하도록 수정
refactor : 중심 비즈니스 로직 내 흐름 정리
- `buy()`: 매수 주문 로직 메서드 추출
- 주문결과로 후처리하는 `orderApiResultProcess()` 메서드 인자 축소

> 리팩토링 > 변경 사항
AS-IS : 주문 결과 실패 여부를 각 후처리 메서드들에서 체크하고 로직 수행
TO-BE : 주문 결과 실패 여부를 주문 메서드 내에서 확인하도록 하였고, try catch 문 내에 두어 주문 결과가 실패이면 후처리하지 않고 반복문을 순회하는 로직
ㄴ 이로 인해 `orderApiResultProcess()` 메서드에 불필요하게 전달하는 인자 제거. 
> > 후기 : 과거의 제가 왜 매수/도매 주문의 응답 상태를 각각의 후처리 메서드에서 체크하도록 개발했는지 의문이네요..허허

----

> 참고. 상속 구현체
- 해외 예약 매수 주문 : `OverseasReservationBuyOrderService`
- 예약 매수 주문 : `ReservationBuyOrderService`
- 해외 매수 주문 : `OverseasBuyOrderServiceImpl`
- 해외 매도 주문 : `OverseasSellOrderServiceImpl`
- 국내 매수 주문 : `BuyOrderServiceImpl`
- 국내 매도 주문 : `SellOrderServiceImpl`